### PR TITLE
Use TlsCrypto to determine which NamedGroup are allowed/supported and

### DIFF
--- a/tls/src/main/java/org/bouncycastle/tls/AbstractTlsClient.java
+++ b/tls/src/main/java/org/bouncycastle/tls/AbstractTlsClient.java
@@ -186,13 +186,33 @@ public abstract class AbstractTlsClient
              * TODO Could just add all the EC groups since we support them all, but users may not
              * want to use unnecessarily large groups. Need configuration options.
              */
-            supportedGroups.addElement(NamedGroup.secp256r1);
-            supportedGroups.addElement(NamedGroup.secp384r1);
+            int[] supportedCurves = NamedGroup.getSupportedCurves();
+            for (int curve : supportedCurves) 
+            {
+                if(getCrypto().hasNamedGroup(curve)) 
+                {
+                    supportedGroups.addElement(curve);
+                }
+            }
 
-            this.clientECPointFormats = new short[]{ ECPointFormat.uncompressed,
-                ECPointFormat.ansiX962_compressed_prime, ECPointFormat.ansiX962_compressed_char2, };
+            short[] supportedFormats = ECPointFormat.getSupportedFormats();
 
-            TlsECCUtils.addSupportedPointFormatsExtension(clientExtensions, clientECPointFormats);
+            Vector<Short> clientECPointFormats = new Vector<Short>();
+            for (short format : supportedFormats) 
+            {
+                if(getCrypto().hasECPointFormat(format)) 
+                {
+                    clientECPointFormats.addElement(format);
+                }
+            }
+            
+            this.clientECPointFormats = new short[clientECPointFormats.size()];
+            for (int i = 0; i < clientECPointFormats.size(); i++) 
+            {
+                this.clientECPointFormats[i] = clientECPointFormats.get(i);
+            }
+            
+            TlsECCUtils.addSupportedPointFormatsExtension(clientExtensions, this.clientECPointFormats);
         }
 
         if (TlsDHUtils.containsDHECipherSuites(cipherSuites))
@@ -201,9 +221,14 @@ public abstract class AbstractTlsClient
              * TODO Could just add all the FFDHE groups since we support them all, but users may not
              * want to use unnecessarily large groups. Need configuration options.
              */
-            supportedGroups.addElement(NamedGroup.ffdhe2048);
-            supportedGroups.addElement(NamedGroup.ffdhe3072);
-            supportedGroups.addElement(NamedGroup.ffdhe4096);
+            int[] supportedFiniteFields = NamedGroup.getSupportedFiniteFields();
+            for (int finiteFields : supportedFiniteFields) 
+            {
+                if(getCrypto().hasNamedGroup(finiteFields)) 
+                {
+                    supportedGroups.addElement(finiteFields);
+                }
+            }
         }
 
         if (!supportedGroups.isEmpty())

--- a/tls/src/main/java/org/bouncycastle/tls/AbstractTlsServer.java
+++ b/tls/src/main/java/org/bouncycastle/tls/AbstractTlsServer.java
@@ -138,7 +138,7 @@ public abstract class AbstractTlsServer
         for (int i = 0; i < clientSupportedGroups.length; ++i)
         {
             int namedGroup = clientSupportedGroups[i];
-            if (NamedGroup.getCurveBits(namedGroup) >= minimumCurveBits)
+            if (NamedGroup.getCurveBits(namedGroup) >= minimumCurveBits && getCrypto().hasNamedGroup(namedGroup))
             {
                 return namedGroup;
             }

--- a/tls/src/main/java/org/bouncycastle/tls/ECPointFormat.java
+++ b/tls/src/main/java/org/bouncycastle/tls/ECPointFormat.java
@@ -12,4 +12,15 @@ public class ECPointFormat
     /*
      * reserved (248..255)
      */
+    
+    public static short[] getSupportedFormats() 
+    {
+        short[] format = new short[ansiX962_compressed_char2];
+        for (short i = 0; i < ansiX962_compressed_char2; i++) 
+        {
+            format[i] = i;
+        }
+        return format;
+    }
+    
 }

--- a/tls/src/main/java/org/bouncycastle/tls/NamedGroup.java
+++ b/tls/src/main/java/org/bouncycastle/tls/NamedGroup.java
@@ -203,6 +203,22 @@ public class NamedGroup
     {
         return getName(namedGroup) + "(" + namedGroup + ")";
     }
+    
+    public static int[] getSupportedCurves() 
+    {
+        int[] curves = new int[brainpoolP512r1];
+        for (int i = 0; i < brainpoolP512r1; i++) 
+        {
+            curves[i] = i+1;
+        }
+        return curves;
+    }
+    
+    public static int[] getSupportedFiniteFields() 
+    {
+        int[] finiteFields = new int[] { ffdhe2048, ffdhe3072, ffdhe4096, ffdhe6144, ffdhe8192 };
+        return finiteFields;
+    }
 
     public static boolean isChar2Curve(int namedGroup)
     {

--- a/tls/src/main/java/org/bouncycastle/tls/crypto/TlsCrypto.java
+++ b/tls/src/main/java/org/bouncycastle/tls/crypto/TlsCrypto.java
@@ -69,6 +69,13 @@ public interface TlsCrypto
     boolean hasNamedGroup(int namedGroup);
 
     /**
+     * Return true if this TlsCrypto supports the passed in {@link ECPointFormat format} value.
+     *
+     * @return true if this instance supports the passed in {@link ECPointFormat format} value.
+     */
+    boolean hasECPointFormat(short format);
+
+    /**
      * Return true if this TlsCrypto can support RSA encryption/decryption.
      *
      * @return true if this instance can support RSA encryption/decryption, false otherwise.

--- a/tls/src/main/java/org/bouncycastle/tls/crypto/impl/bc/BcTlsCrypto.java
+++ b/tls/src/main/java/org/bouncycastle/tls/crypto/impl/bc/BcTlsCrypto.java
@@ -45,6 +45,7 @@ import org.bouncycastle.crypto.params.RSAKeyParameters;
 import org.bouncycastle.crypto.params.SRP6GroupParameters;
 import org.bouncycastle.crypto.prng.DigestRandomGenerator;
 import org.bouncycastle.tls.AlertDescription;
+import org.bouncycastle.tls.ECPointFormat;
 import org.bouncycastle.tls.EncryptionAlgorithm;
 import org.bouncycastle.tls.HashAlgorithm;
 import org.bouncycastle.tls.NamedGroup;
@@ -286,7 +287,25 @@ public class BcTlsCrypto
 
     public boolean hasNamedGroup(int namedGroup)
     {
-        return NamedGroup.refersToASpecificGroup(namedGroup);
+        switch (namedGroup)
+        {
+        case NamedGroup.secp256r1:
+        case NamedGroup.secp384r1:
+        case NamedGroup.ffdhe2048:
+        case NamedGroup.ffdhe3072:
+        case NamedGroup.ffdhe4096:
+        case NamedGroup.ffdhe6144:
+        case NamedGroup.ffdhe8192:
+            return NamedGroup.refersToASpecificGroup(namedGroup);
+
+        default:
+            return false;
+        }
+    }
+    
+    public boolean hasECPointFormat(short format) 
+    {
+        return format >= ECPointFormat.uncompressed &&  format <= ECPointFormat.ansiX962_compressed_char2;
     }
 
     public boolean hasRSAEncryption()


### PR DESCRIPTION
therefore are part of the ClientHello message respectively are selected
by the server.

The old fixed values (secp256r1, secp384r1, ffdhe2048, ffdhe3072,
ffdhe4096, ffdhe6144, ffdhe8192) are still fixed, by only returning them
as supported NamedGroup in the existing TlsCrypto implementations
(BcTlsCrypto and JcaTlsCrypto). By implementing an own TlsCrypto
implementation the fixed values can now be changed.