### PR TITLE
bugfix/EKON-3757_defensive_copy_for_ASN1OctetString_content

### DIFF
--- a/core/src/main/java/org/bouncycastle/asn1/ASN1GeneralizedTime.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ASN1GeneralizedTime.java
@@ -165,7 +165,7 @@ public class ASN1GeneralizedTime
         {
             throw new IllegalArgumentException("GeneralizedTime string too short");
         }
-        this.time = bytes;
+        this.time = Arrays.clone(bytes);
 
         if (!(isDigit(0) && isDigit(1) && isDigit(2) && isDigit(3)))
         {

--- a/core/src/main/java/org/bouncycastle/asn1/ASN1UTCTime.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ASN1UTCTime.java
@@ -155,7 +155,7 @@ public class ASN1UTCTime
         {
             throw new IllegalArgumentException("UTCTime string too short");
         }
-        this.time = time;
+        this.time = Arrays.clone(time);
         if (!(isDigit(0) && isDigit(1)))
         {
             throw new IllegalArgumentException("illegal characters in UTCTime string");

--- a/core/src/main/java/org/bouncycastle/asn1/DERGeneralString.java
+++ b/core/src/main/java/org/bouncycastle/asn1/DERGeneralString.java
@@ -77,7 +77,7 @@ public class DERGeneralString
 
     DERGeneralString(byte[] string)
     {
-        this.string = string;
+        this.string = Arrays.clone(string);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/DERIA5String.java
+++ b/core/src/main/java/org/bouncycastle/asn1/DERIA5String.java
@@ -80,7 +80,7 @@ public class DERIA5String
     DERIA5String(
         byte[]   string)
     {
-        this.string = string;
+        this.string = Arrays.clone(string);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/DERNumericString.java
+++ b/core/src/main/java/org/bouncycastle/asn1/DERNumericString.java
@@ -83,7 +83,7 @@ public class DERNumericString
     DERNumericString(
         byte[]   string)
     {
-        this.string = string;
+        this.string = Arrays.clone(string);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/DERPrintableString.java
+++ b/core/src/main/java/org/bouncycastle/asn1/DERPrintableString.java
@@ -99,7 +99,7 @@ public class DERPrintableString
     DERPrintableString(
         byte[]   string)
     {
-        this.string = string;
+        this.string = Arrays.clone(string);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/DERT61UTF8String.java
+++ b/core/src/main/java/org/bouncycastle/asn1/DERT61UTF8String.java
@@ -83,7 +83,7 @@ public class DERT61UTF8String
     public DERT61UTF8String(
         byte[] string)
     {
-        this.string = string;
+        this.string = Arrays.clone(string);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/DERUTF8String.java
+++ b/core/src/main/java/org/bouncycastle/asn1/DERUTF8String.java
@@ -78,7 +78,7 @@ public class DERUTF8String
      */
     DERUTF8String(byte[] string)
     {
-        this.string = string;
+        this.string = Arrays.clone(string);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/DERVisibleString.java
+++ b/core/src/main/java/org/bouncycastle/asn1/DERVisibleString.java
@@ -79,7 +79,7 @@ public class DERVisibleString
     DERVisibleString(
         byte[]   string)
     {
-        this.string = string;
+        this.string = Arrays.clone(string);
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/cmp/Challenge.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cmp/Challenge.java
@@ -9,6 +9,7 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.util.Arrays;
 
 public class Challenge
     extends ASN1Object
@@ -64,12 +65,12 @@ public class Challenge
 
     public byte[] getWitness()
     {
-        return witness.getOctets();
+        return Arrays.clone(witness.getOctets());
     }
 
     public byte[] getChallenge()
     {
-        return challenge.getOctets();
+        return Arrays.clone(challenge.getOctets());
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/cms/CCMParameters.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/CCMParameters.java
@@ -56,7 +56,7 @@ public class CCMParameters
     private CCMParameters(
         ASN1Sequence seq)
     {
-        this.nonce = ASN1OctetString.getInstance(seq.getObjectAt(0)).getOctets();
+        this.nonce = Arrays.clone(ASN1OctetString.getInstance(seq.getObjectAt(0)).getOctets());
 
         if (seq.size() == 2)
         {
@@ -90,7 +90,7 @@ public class CCMParameters
     {
         ASN1EncodableVector v = new ASN1EncodableVector(2);
 
-        v.add(new DEROctetString(nonce));
+        v.add(new DEROctetString(getNonce()));
 
         if (icvLen != 12)
         {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/DigestedData.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/DigestedData.java
@@ -10,6 +10,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.BERSequence;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.util.Arrays;
 
 /** 
  * <a href="http://tools.ietf.org/html/rfc5652#section-7">RFC 5652</a> DigestedData object.
@@ -123,6 +124,6 @@ public class DigestedData
 
     public byte[] getDigest()
     {
-        return digest.getOctets();
+        return Arrays.clone(digest.getOctets());
     }
 }

--- a/core/src/main/java/org/bouncycastle/asn1/cms/GCMParameters.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/GCMParameters.java
@@ -56,7 +56,7 @@ public class GCMParameters
     private GCMParameters(
         ASN1Sequence seq)
     {
-        this.nonce = ASN1OctetString.getInstance(seq.getObjectAt(0)).getOctets();
+        this.nonce = Arrays.clone(ASN1OctetString.getInstance(seq.getObjectAt(0)).getOctets());
 
         if (seq.size() == 2)
         {
@@ -90,7 +90,7 @@ public class GCMParameters
     {
         ASN1EncodableVector v = new ASN1EncodableVector(2);
 
-        v.add(new DEROctetString(nonce));
+        v.add(new DEROctetString(getNonce()));
 
         if (icvLen != 12)
         {

--- a/core/src/main/java/org/bouncycastle/asn1/cms/ecc/ECCCMSSharedInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cms/ecc/ECCCMSSharedInfo.java
@@ -55,12 +55,12 @@ public class ECCCMSSharedInfo
         if (seq.size() == 2)
         {
             this.entityUInfo = null;
-            this.suppPubInfo = ASN1OctetString.getInstance((ASN1TaggedObject)seq.getObjectAt(1), true).getOctets();
+            this.suppPubInfo = Arrays.clone(ASN1OctetString.getInstance((ASN1TaggedObject)seq.getObjectAt(1), true).getOctets());
         }
         else
         {
-            this.entityUInfo = ASN1OctetString.getInstance((ASN1TaggedObject)seq.getObjectAt(1), true).getOctets();
-            this.suppPubInfo = ASN1OctetString.getInstance((ASN1TaggedObject)seq.getObjectAt(2), true).getOctets();
+            this.entityUInfo = Arrays.clone(ASN1OctetString.getInstance((ASN1TaggedObject)seq.getObjectAt(1), true).getOctets());
+            this.suppPubInfo = Arrays.clone(ASN1OctetString.getInstance((ASN1TaggedObject)seq.getObjectAt(2), true).getOctets());
         }
     }
 

--- a/core/src/main/java/org/bouncycastle/asn1/cryptopro/Gost2814789KeyWrapParameters.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cryptopro/Gost2814789KeyWrapParameters.java
@@ -21,7 +21,7 @@ public class Gost2814789KeyWrapParameters
         if (seq.size() == 2)
         {
             this.encryptionParamSet = ASN1ObjectIdentifier.getInstance(seq.getObjectAt(0));
-            this.ukm = ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets();
+            this.ukm = Arrays.clone(ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets());
         }
         else if (seq.size() == 1)
         {

--- a/core/src/main/java/org/bouncycastle/asn1/cryptopro/GostR3410TransportParameters.java
+++ b/core/src/main/java/org/bouncycastle/asn1/cryptopro/GostR3410TransportParameters.java
@@ -41,7 +41,7 @@ public class GostR3410TransportParameters
         if (seq.size() == 2)
         {
             this.encryptionParamSet = ASN1ObjectIdentifier.getInstance(seq.getObjectAt(0));
-            this.ukm = ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets();
+            this.ukm = Arrays.clone(ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets());
             this.ephemeralPublicKey = null;
         }
         else if (seq.size() == 3)
@@ -49,7 +49,7 @@ public class GostR3410TransportParameters
             this.encryptionParamSet = ASN1ObjectIdentifier.getInstance(seq.getObjectAt(0));
             this.ephemeralPublicKey = SubjectPublicKeyInfo.getInstance(
                 ASN1TaggedObject.getInstance(seq.getObjectAt(1)), false);
-            this.ukm = ASN1OctetString.getInstance(seq.getObjectAt(2)).getOctets();
+            this.ukm = Arrays.clone(ASN1OctetString.getInstance(seq.getObjectAt(2)).getOctets());
         }
         else
         {

--- a/core/src/main/java/org/bouncycastle/asn1/eac/ECDSAPublicKey.java
+++ b/core/src/main/java/org/bouncycastle/asn1/eac/ECDSAPublicKey.java
@@ -144,7 +144,7 @@ public class ECDSAPublicKey
         if ((options & G) == 0)
         {
             options |= G;
-            this.basePointG = basePointG.getOctets();
+            this.basePointG = Arrays.clone(basePointG.getOctets());
         }
         else
         {
@@ -273,7 +273,7 @@ public class ECDSAPublicKey
         if ((options & Y) == 0)
         {
             options |= Y;
-            this.publicPointY = publicPointY.getOctets();
+            this.publicPointY = Arrays.clone(publicPointY.getOctets());
         }
         else
         {

--- a/core/src/main/java/org/bouncycastle/asn1/esf/OtherHash.java
+++ b/core/src/main/java/org/bouncycastle/asn1/esf/OtherHash.java
@@ -7,6 +7,7 @@ import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.util.Arrays;
 
 /**
  * <pre>
@@ -65,9 +66,9 @@ public class OtherHash
     {
         if (null == this.otherHash)
         {
-            return this.sha1Hash.getOctets();
+            return Arrays.clone(this.sha1Hash.getOctets());
         }
-        return this.otherHash.getHashValue().getOctets();
+        return Arrays.clone(this.otherHash.getHashValue().getOctets());
     }
 
     public ASN1Primitive toASN1Primitive()

--- a/core/src/main/java/org/bouncycastle/asn1/ess/ESSCertID.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ess/ESSCertID.java
@@ -8,6 +8,7 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.IssuerSerial;
+import org.bouncycastle.util.Arrays;
 
 public class ESSCertID
     extends ASN1Object
@@ -64,7 +65,7 @@ public class ESSCertID
 
     public byte[] getCertHash()
     {
-        return certHash.getOctets();
+        return Arrays.clone(certHash.getOctets());
     }
 
     public IssuerSerial getIssuerSerial()

--- a/core/src/main/java/org/bouncycastle/asn1/ess/ESSCertIDv2.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ess/ESSCertIDv2.java
@@ -55,7 +55,7 @@ public class ESSCertIDv2
             this.hashAlgorithm = AlgorithmIdentifier.getInstance(seq.getObjectAt(count++).toASN1Primitive());
         }
 
-        this.certHash = ASN1OctetString.getInstance(seq.getObjectAt(count++).toASN1Primitive()).getOctets();
+        this.certHash = Arrays.clone(ASN1OctetString.getInstance(seq.getObjectAt(count++).toASN1Primitive()).getOctets());
 
         if (seq.size() > count)
         {
@@ -143,7 +143,7 @@ public class ESSCertIDv2
             v.add(hashAlgorithm);
         }
 
-        v.add(new DEROctetString(certHash).toASN1Primitive());
+        v.add(new DEROctetString(getCertHash()).toASN1Primitive());
 
         if (issuerSerial != null)
         {

--- a/core/src/main/java/org/bouncycastle/asn1/ess/OtherCertID.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ess/OtherCertID.java
@@ -11,6 +11,7 @@ import org.bouncycastle.asn1.oiw.OIWObjectIdentifiers;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.asn1.x509.DigestInfo;
 import org.bouncycastle.asn1.x509.IssuerSerial;
+import org.bouncycastle.util.Arrays;
 
 public class OtherCertID
     extends ASN1Object
@@ -93,7 +94,7 @@ public class OtherCertID
         if (otherCertHash.toASN1Primitive() instanceof ASN1OctetString)
         {
             // SHA-1
-            return ((ASN1OctetString)otherCertHash.toASN1Primitive()).getOctets();
+            return Arrays.clone(((ASN1OctetString)otherCertHash.toASN1Primitive()).getOctets());
         }
         else
         {

--- a/core/src/main/java/org/bouncycastle/asn1/isismtt/ocsp/CertHash.java
+++ b/core/src/main/java/org/bouncycastle/asn1/isismtt/ocsp/CertHash.java
@@ -71,7 +71,7 @@ public class CertHash
                 + seq.size());
         }
         hashAlgorithm = AlgorithmIdentifier.getInstance(seq.getObjectAt(0));
-        certificateHash = DEROctetString.getInstance(seq.getObjectAt(1)).getOctets();
+        certificateHash = Arrays.clone(DEROctetString.getInstance(seq.getObjectAt(1)).getOctets());
     }
 
     /**
@@ -115,7 +115,7 @@ public class CertHash
     {
         ASN1EncodableVector vec = new ASN1EncodableVector(2);
         vec.add(hashAlgorithm);
-        vec.add(new DEROctetString(certificateHash));
+        vec.add(new DEROctetString(getCertificateHash()));
         return new DERSequence(vec);
     }
 }

--- a/core/src/main/java/org/bouncycastle/asn1/isismtt/ocsp/RequestedCertificate.java
+++ b/core/src/main/java/org/bouncycastle/asn1/isismtt/ocsp/RequestedCertificate.java
@@ -91,11 +91,11 @@ public class RequestedCertificate
     {
         if (tagged.getTagNo() == publicKeyCertificate)
         {
-            publicKeyCert = ASN1OctetString.getInstance(tagged, true).getOctets();
+            publicKeyCert = Arrays.clone(ASN1OctetString.getInstance(tagged, true).getOctets());
         }
         else if (tagged.getTagNo() == attributeCertificate)
         {
-            attributeCert = ASN1OctetString.getInstance(tagged, true).getOctets();
+            attributeCert = Arrays.clone(ASN1OctetString.getInstance(tagged, true).getOctets());
         }
         else
         {

--- a/core/src/main/java/org/bouncycastle/asn1/ocsp/ResponderID.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ocsp/ResponderID.java
@@ -9,6 +9,7 @@ import org.bouncycastle.asn1.ASN1TaggedObject;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.util.Arrays;
 
 public class ResponderID
     extends ASN1Object
@@ -68,7 +69,7 @@ public class ResponderID
         if (this.value instanceof ASN1OctetString)
         {
             ASN1OctetString octetString = (ASN1OctetString)this.value;
-            return octetString.getOctets();
+            return Arrays.clone(octetString.getOctets());
         }
 
         return null;

--- a/core/src/main/java/org/bouncycastle/asn1/pkcs/EncryptedPrivateKeyInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/pkcs/EncryptedPrivateKeyInfo.java
@@ -10,6 +10,7 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.util.Arrays;
 
 public class EncryptedPrivateKeyInfo
     extends ASN1Object
@@ -56,7 +57,7 @@ public class EncryptedPrivateKeyInfo
 
     public byte[] getEncryptedData()
     {
-        return data.getOctets();
+        return Arrays.clone(data.getOctets());
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/pkcs/PBEParameter.java
+++ b/core/src/main/java/org/bouncycastle/asn1/pkcs/PBEParameter.java
@@ -10,6 +10,7 @@ import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.util.Arrays;
 
 public class PBEParameter
     extends ASN1Object
@@ -58,7 +59,7 @@ public class PBEParameter
 
     public byte[] getSalt()
     {
-        return salt.getOctets();
+        return Arrays.clone(salt.getOctets());
     }
 
     public ASN1Primitive toASN1Primitive()

--- a/core/src/main/java/org/bouncycastle/asn1/pkcs/PBKDF2Params.java
+++ b/core/src/main/java/org/bouncycastle/asn1/pkcs/PBKDF2Params.java
@@ -183,7 +183,7 @@ public class PBKDF2Params
      */
     public byte[] getSalt()
     {
-        return octStr.getOctets();
+        return Arrays.clone(octStr.getOctets());
     }
 
     /**

--- a/core/src/main/java/org/bouncycastle/asn1/pkcs/PKCS12PBEParams.java
+++ b/core/src/main/java/org/bouncycastle/asn1/pkcs/PKCS12PBEParams.java
@@ -10,6 +10,7 @@ import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.util.Arrays;
 
 public class PKCS12PBEParams
     extends ASN1Object
@@ -54,7 +55,7 @@ public class PKCS12PBEParams
 
     public byte[] getIV()
     {
-        return iv.getOctets();
+        return Arrays.clone(iv.getOctets());
     }
 
     public ASN1Primitive toASN1Primitive()

--- a/core/src/main/java/org/bouncycastle/asn1/pkcs/RC2CBCParameter.java
+++ b/core/src/main/java/org/bouncycastle/asn1/pkcs/RC2CBCParameter.java
@@ -10,6 +10,7 @@ import org.bouncycastle.asn1.ASN1Primitive;
 import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.util.Arrays;
 
 public class RC2CBCParameter
     extends ASN1Object
@@ -74,7 +75,7 @@ public class RC2CBCParameter
 
     public byte[] getIV()
     {
-        return iv.getOctets();
+        return Arrays.clone(iv.getOctets());
     }
 
     public ASN1Primitive toASN1Primitive()

--- a/core/src/main/java/org/bouncycastle/asn1/tsp/MessageImprint.java
+++ b/core/src/main/java/org/bouncycastle/asn1/tsp/MessageImprint.java
@@ -39,7 +39,7 @@ public class MessageImprint
         ASN1Sequence seq)
     {
         this.hashAlgorithm = AlgorithmIdentifier.getInstance(seq.getObjectAt(0));
-        this.hashedMessage = ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets();
+        this.hashedMessage = Arrays.clone(ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets());
     }
     
     public MessageImprint(

--- a/core/src/main/java/org/bouncycastle/asn1/ua/DSTU4145Params.java
+++ b/core/src/main/java/org/bouncycastle/asn1/ua/DSTU4145Params.java
@@ -92,7 +92,7 @@ public class DSTU4145Params
 
             if (seq.size() == 2)
             {
-                params.dke = ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets();
+                params.dke = Arrays.clone(ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets());
                 if (params.dke.length != DSTU4145Params.DEFAULT_DKE.length)
                 {
                     throw new IllegalArgumentException("object parse error");

--- a/core/src/main/java/org/bouncycastle/asn1/x509/AuthorityKeyIdentifier.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/AuthorityKeyIdentifier.java
@@ -15,6 +15,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.DERTaggedObject;
 import org.bouncycastle.crypto.Digest;
 import org.bouncycastle.crypto.digests.SHA1Digest;
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.encoders.Hex;
 
 /**
@@ -176,7 +177,7 @@ public class AuthorityKeyIdentifier
     {
         if (keyidentifier != null)
         {
-            return keyidentifier.getOctets();
+            return Arrays.clone(keyidentifier.getOctets());
         }
 
         return null;

--- a/core/src/main/java/org/bouncycastle/asn1/x509/DigestInfo.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/DigestInfo.java
@@ -62,7 +62,7 @@ public class DigestInfo
         Enumeration             e = obj.getObjects();
 
         algId = AlgorithmIdentifier.getInstance(e.nextElement());
-        digest = ASN1OctetString.getInstance(e.nextElement()).getOctets();
+        digest = Arrays.clone(ASN1OctetString.getInstance(e.nextElement()).getOctets());
     }
 
     public AlgorithmIdentifier getAlgorithmId()
@@ -80,7 +80,7 @@ public class DigestInfo
         ASN1EncodableVector v = new ASN1EncodableVector(2);
 
         v.add(algId);
-        v.add(new DEROctetString(digest));
+        v.add(new DEROctetString(getDigest()));
 
         return new DERSequence(v);
     }

--- a/core/src/main/java/org/bouncycastle/asn1/x509/PKIXNameConstraintValidator.java
+++ b/core/src/main/java/org/bouncycastle/asn1/x509/PKIXNameConstraintValidator.java
@@ -254,8 +254,8 @@ public class PKIXNameConstraintValidator
                 extractNameAsString(base));
             break;
         case GeneralName.iPAddress:
-            excludedSubtreesIP = unionIP(excludedSubtreesIP, ASN1OctetString
-                .getInstance(base.getName()).getOctets());
+            excludedSubtreesIP = unionIP(excludedSubtreesIP, Arrays.clone(ASN1OctetString
+                .getInstance(base.getName()).getOctets()));
             break;
         default:
             throw new IllegalStateException("Unknown tag encountered: " + base.getTagNo());
@@ -624,8 +624,8 @@ public class PKIXNameConstraintValidator
         Set intersect = new HashSet();
         for (Iterator it = ips.iterator(); it.hasNext();)
         {
-            byte[] ip = ASN1OctetString.getInstance(
-                ((GeneralSubtree)it.next()).getBase().getName()).getOctets();
+            byte[] ip = Arrays.clone(ASN1OctetString.getInstance(
+                ((GeneralSubtree)it.next()).getBase().getName()).getOctets());
             if (permitted == null)
             {
                 if (ip != null)

--- a/core/src/main/java/org/bouncycastle/pqc/asn1/GMSSPublicKey.java
+++ b/core/src/main/java/org/bouncycastle/pqc/asn1/GMSSPublicKey.java
@@ -34,7 +34,7 @@ public class GMSSPublicKey
         }
 
         this.version = ASN1Integer.getInstance(seq.getObjectAt(0));
-        this.publicKey = ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets();
+        this.publicKey = Arrays.clone(ASN1OctetString.getInstance(seq.getObjectAt(1)).getOctets());
     }
 
     public GMSSPublicKey(byte[] publicKeyBytes)

--- a/core/src/main/java/org/bouncycastle/pqc/asn1/McElieceCCA2PrivateKey.java
+++ b/core/src/main/java/org/bouncycastle/pqc/asn1/McElieceCCA2PrivateKey.java
@@ -14,6 +14,7 @@ import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
 import org.bouncycastle.pqc.math.linearalgebra.GF2mField;
 import org.bouncycastle.pqc.math.linearalgebra.Permutation;
 import org.bouncycastle.pqc.math.linearalgebra.PolynomialGF2mSmallM;
+import org.bouncycastle.util.Arrays;
 
 /**
  * Return the keyData to encode in the PrivateKeyInfo structure.
@@ -58,11 +59,11 @@ public class McElieceCCA2PrivateKey
 
         k = ((ASN1Integer)seq.getObjectAt(1)).intValueExact();
 
-        encField = ((ASN1OctetString)seq.getObjectAt(2)).getOctets();
+        encField = Arrays.clone(((ASN1OctetString)seq.getObjectAt(2)).getOctets());
 
-        encGp = ((ASN1OctetString)seq.getObjectAt(3)).getOctets();
+        encGp = Arrays.clone(((ASN1OctetString)seq.getObjectAt(3)).getOctets());
 
-        encP = ((ASN1OctetString)seq.getObjectAt(4)).getOctets();
+        encP = Arrays.clone(((ASN1OctetString)seq.getObjectAt(4)).getOctets());
 
         digest = AlgorithmIdentifier.getInstance(seq.getObjectAt(5));
     }

--- a/core/src/main/java/org/bouncycastle/pqc/asn1/McEliecePrivateKey.java
+++ b/core/src/main/java/org/bouncycastle/pqc/asn1/McEliecePrivateKey.java
@@ -14,6 +14,7 @@ import org.bouncycastle.pqc.math.linearalgebra.GF2Matrix;
 import org.bouncycastle.pqc.math.linearalgebra.GF2mField;
 import org.bouncycastle.pqc.math.linearalgebra.Permutation;
 import org.bouncycastle.pqc.math.linearalgebra.PolynomialGF2mSmallM;
+import org.bouncycastle.util.Arrays;
 
 public class McEliecePrivateKey
     extends ASN1Object
@@ -57,15 +58,15 @@ public class McEliecePrivateKey
 
         k = ((ASN1Integer)seq.getObjectAt(1)).intValueExact();
 
-        encField = ((ASN1OctetString)seq.getObjectAt(2)).getOctets();
+        encField = Arrays.clone(((ASN1OctetString)seq.getObjectAt(2)).getOctets());
 
-        encGp = ((ASN1OctetString)seq.getObjectAt(3)).getOctets();
+        encGp = Arrays.clone(((ASN1OctetString)seq.getObjectAt(3)).getOctets());
 
-        encP1 = ((ASN1OctetString)seq.getObjectAt(4)).getOctets();
+        encP1 = Arrays.clone(((ASN1OctetString)seq.getObjectAt(4)).getOctets());
 
-        encP2 = ((ASN1OctetString)seq.getObjectAt(5)).getOctets();
+        encP2 = Arrays.clone(((ASN1OctetString)seq.getObjectAt(5)).getOctets());
 
-        encSInv = ((ASN1OctetString)seq.getObjectAt(6)).getOctets();
+        encSInv = Arrays.clone(((ASN1OctetString)seq.getObjectAt(6)).getOctets());
     }
 
     public int getN()

--- a/core/src/main/java/org/bouncycastle/pqc/asn1/RainbowPrivateKey.java
+++ b/core/src/main/java/org/bouncycastle/pqc/asn1/RainbowPrivateKey.java
@@ -11,6 +11,7 @@ import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.pqc.crypto.rainbow.Layer;
 import org.bouncycastle.pqc.crypto.rainbow.util.RainbowUtil;
+import org.bouncycastle.util.Arrays;
 
 /**
  * Return the key data to encode in the PrivateKeyInfo structure.
@@ -71,28 +72,28 @@ public class RainbowPrivateKey
         invA1 = new byte[asnA1.size()][];
         for (int i = 0; i < asnA1.size(); i++)
         {
-            invA1[i] = ((ASN1OctetString)asnA1.getObjectAt(i)).getOctets();
+            invA1[i] = Arrays.clone(((ASN1OctetString)asnA1.getObjectAt(i)).getOctets());
         }
 
         // <b1>
         ASN1Sequence asnb1 = (ASN1Sequence)seq.getObjectAt(2);
-        b1 = ((ASN1OctetString)asnb1.getObjectAt(0)).getOctets();
+        b1 = Arrays.clone(((ASN1OctetString)asnb1.getObjectAt(0)).getOctets());
 
         // <A2inv>
         ASN1Sequence asnA2 = (ASN1Sequence)seq.getObjectAt(3);
         invA2 = new byte[asnA2.size()][];
         for (int j = 0; j < asnA2.size(); j++)
         {
-            invA2[j] = ((ASN1OctetString)asnA2.getObjectAt(j)).getOctets();
+            invA2[j] = Arrays.clone(((ASN1OctetString)asnA2.getObjectAt(j)).getOctets());
         }
 
         // <b2>
         ASN1Sequence asnb2 = (ASN1Sequence)seq.getObjectAt(4);
-        b2 = ((ASN1OctetString)asnb2.getObjectAt(0)).getOctets();
+        b2 = Arrays.clone(((ASN1OctetString)asnb2.getObjectAt(0)).getOctets());
 
         // <vi>
         ASN1Sequence asnvi = (ASN1Sequence)seq.getObjectAt(5);
-        vi = ((ASN1OctetString)asnvi.getObjectAt(0)).getOctets();
+        vi = Arrays.clone(((ASN1OctetString)asnvi.getObjectAt(0)).getOctets());
 
         // <layers>
         ASN1Sequence asnLayers = (ASN1Sequence)seq.getObjectAt(6);
@@ -115,7 +116,7 @@ public class RainbowPrivateKey
                 alphas[l][m] = new byte[alphas2d.size()][];
                 for (int n = 0; n < alphas2d.size(); n++)
                 {
-                    alphas[l][m][n] = ((ASN1OctetString)alphas2d.getObjectAt(n)).getOctets();
+                    alphas[l][m][n] = Arrays.clone(((ASN1OctetString)alphas2d.getObjectAt(n)).getOctets());
                 }
             }
 
@@ -128,7 +129,7 @@ public class RainbowPrivateKey
                 betas[l][mb] = new byte[betas2d.size()][];
                 for (int nb = 0; nb < betas2d.size(); nb++)
                 {
-                    betas[l][mb][nb] = ((ASN1OctetString)betas2d.getObjectAt(nb)).getOctets();
+                    betas[l][mb][nb] = Arrays.clone(((ASN1OctetString)betas2d.getObjectAt(nb)).getOctets());
                 }
             }
 
@@ -137,11 +138,11 @@ public class RainbowPrivateKey
             gammas[l] = new byte[gammas2d.size()][];
             for (int mg = 0; mg < gammas2d.size(); mg++)
             {
-                gammas[l][mg] = ((ASN1OctetString)gammas2d.getObjectAt(mg)).getOctets();
+                gammas[l][mg] = Arrays.clone(((ASN1OctetString)gammas2d.getObjectAt(mg)).getOctets());
             }
 
             // eta ...
-            etas[l] = ((ASN1OctetString)asnLayer.getObjectAt(3)).getOctets();
+            etas[l] = Arrays.clone(((ASN1OctetString)asnLayer.getObjectAt(3)).getOctets());
         }
 
         int numOfLayers = vi.length - 1;

--- a/core/src/main/java/org/bouncycastle/pqc/asn1/RainbowPublicKey.java
+++ b/core/src/main/java/org/bouncycastle/pqc/asn1/RainbowPublicKey.java
@@ -10,6 +10,7 @@ import org.bouncycastle.asn1.ASN1Sequence;
 import org.bouncycastle.asn1.DEROctetString;
 import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.pqc.crypto.rainbow.util.RainbowUtil;
+import org.bouncycastle.util.Arrays;
 
 /**
  * This class implements an ASN.1 encoded Rainbow public key. The ASN.1 definition
@@ -56,18 +57,18 @@ public class RainbowPublicKey
         coeffQuadratic = new byte[asnCoeffQuad.size()][];
         for (int quadSize = 0; quadSize < asnCoeffQuad.size(); quadSize++)
         {
-            coeffQuadratic[quadSize] = ASN1OctetString.getInstance(asnCoeffQuad.getObjectAt(quadSize)).getOctets();
+            coeffQuadratic[quadSize] = Arrays.clone(ASN1OctetString.getInstance(asnCoeffQuad.getObjectAt(quadSize)).getOctets());
         }
 
         ASN1Sequence asnCoeffSing = (ASN1Sequence)seq.getObjectAt(3);
         coeffSingular = new byte[asnCoeffSing.size()][];
         for (int singSize = 0; singSize < asnCoeffSing.size(); singSize++)
         {
-            coeffSingular[singSize] = ASN1OctetString.getInstance(asnCoeffSing.getObjectAt(singSize)).getOctets();
+            coeffSingular[singSize] = Arrays.clone(ASN1OctetString.getInstance(asnCoeffSing.getObjectAt(singSize)).getOctets());
         }
 
         ASN1Sequence asnCoeffScalar = (ASN1Sequence)seq.getObjectAt(4);
-        coeffScalar = ASN1OctetString.getInstance(asnCoeffScalar.getObjectAt(0)).getOctets();
+        coeffScalar = Arrays.clone(ASN1OctetString.getInstance(asnCoeffScalar.getObjectAt(0)).getOctets());
     }
 
     public RainbowPublicKey(int docLength, short[][] coeffQuadratic, short[][] coeffSingular, short[] coeffScalar)

--- a/pkix/src/main/java/org/bouncycastle/cert/X509ExtensionUtils.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/X509ExtensionUtils.java
@@ -12,6 +12,7 @@ import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.operator.DigestCalculator;
+import org.bouncycastle.util.Arrays;
 
 /**
  * General utility class for creating calculated extensions using the standard methods.
@@ -123,7 +124,7 @@ public class X509ExtensionUtils
 
             if (ext != null)
             {
-                return ASN1OctetString.getInstance(ext.getParsedValue()).getOctets();
+                return Arrays.clone(ASN1OctetString.getInstance(ext.getParsedValue()).getOctets());
             }
             else
             {

--- a/pkix/src/main/java/org/bouncycastle/cert/X509v3CertificateBuilder.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/X509v3CertificateBuilder.java
@@ -26,6 +26,7 @@ import org.bouncycastle.asn1.x509.TBSCertificate;
 import org.bouncycastle.asn1.x509.Time;
 import org.bouncycastle.asn1.x509.V3TBSCertificateGenerator;
 import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.util.Arrays;
 
 
 /**
@@ -344,7 +345,7 @@ public class X509v3CertificateBuilder
             throw new NullPointerException("extension " + oid + " not present");
         }
 
-        extGenerator.addExtension(oid, isCritical, extension.getExtnValue().getOctets());
+        extGenerator.addExtension(oid, isCritical, Arrays.clone(extension.getExtnValue().getOctets()));
 
         return this;
     }

--- a/pkix/src/main/java/org/bouncycastle/cert/jcajce/JcaX509ExtensionUtils.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/jcajce/JcaX509ExtensionUtils.java
@@ -35,6 +35,7 @@ import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.X509ExtensionUtils;
 import org.bouncycastle.operator.DigestCalculator;
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.Integers;
 
 public class JcaX509ExtensionUtils
@@ -175,7 +176,7 @@ public class JcaX509ExtensionUtils
                     list.add(ASN1ObjectIdentifier.getInstance(genName.getName()).getId());
                     break;
                 case GeneralName.iPAddress:
-                    list.add(DEROctetString.getInstance(genName.getName()).getOctets());
+                    list.add(Arrays.clone(DEROctetString.getInstance(genName.getName()).getOctets()));
                     break;
                 default:
                     throw new IOException("Bad tag number: " + genName.getTagNo());

--- a/pkix/src/main/java/org/bouncycastle/cert/ocsp/CertificateID.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/ocsp/CertificateID.java
@@ -17,6 +17,7 @@ import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.operator.DigestCalculator;
 import org.bouncycastle.operator.DigestCalculatorProvider;
 import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.util.Arrays;
 
 public class CertificateID
 {
@@ -58,12 +59,12 @@ public class CertificateID
 
     public byte[] getIssuerNameHash()
     {
-        return id.getIssuerNameHash().getOctets();
+        return Arrays.clone(id.getIssuerNameHash().getOctets());
     }
 
     public byte[] getIssuerKeyHash()
     {
-        return id.getIssuerKeyHash().getOctets();
+        return Arrays.clone(id.getIssuerKeyHash().getOctets());
     }
 
     /**

--- a/pkix/src/main/java/org/bouncycastle/cert/selector/X509CertificateHolderSelector.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/selector/X509CertificateHolderSelector.java
@@ -55,7 +55,7 @@ public class X509CertificateHolderSelector
     {
         this.issuer = issuer;
         this.serialNumber = serialNumber;
-        this.subjectKeyId = subjectKeyId;
+        this.subjectKeyId = Arrays.clone(subjectKeyId);
     }
 
     public X500Name getIssuer()

--- a/pkix/src/main/java/org/bouncycastle/cert/selector/jcajce/JcaX509CertificateHolderSelector.java
+++ b/pkix/src/main/java/org/bouncycastle/cert/selector/jcajce/JcaX509CertificateHolderSelector.java
@@ -9,6 +9,7 @@ import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.selector.X509CertificateHolderSelector;
+import org.bouncycastle.util.Arrays;
 
 public class JcaX509CertificateHolderSelector
     extends X509CertificateHolderSelector
@@ -62,7 +63,7 @@ public class JcaX509CertificateHolderSelector
 
         if (ext != null)
         {
-            return ASN1OctetString.getInstance(ASN1OctetString.getInstance(ext).getOctets()).getOctets();
+            return Arrays.clone(ASN1OctetString.getInstance(ASN1OctetString.getInstance(ext).getOctets()).getOctets());
         }
         else
         {

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSAuthEnvelopedData.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSAuthEnvelopedData.java
@@ -64,12 +64,12 @@ public class CMSAuthEnvelopedData
             public InputStream getInputStream()
                 throws IOException, CMSException
             {
-                return new ByteArrayInputStream(authEncInfo.getEncryptedContent().getOctets());
+                return new ByteArrayInputStream(Arrays.clone(authEncInfo.getEncryptedContent().getOctets()));
             }
         };
 
         this.authAttrs = authEnvData.getAuthAttrs();
-        this.mac = authEnvData.getMac().getOctets();
+        this.mac = Arrays.clone(authEnvData.getMac().getOctets());
         this.unauthAttrs = authEnvData.getUnauthAttrs();
 
         //

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSAuthenticatedData.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSAuthenticatedData.java
@@ -93,7 +93,7 @@ public class CMSAuthenticatedData
         this.macAlg = authData.getMacAlgorithm();
 
         this.authAttrs = authData.getAuthAttrs();
-        this.mac = authData.getMac().getOctets();
+        this.mac = Arrays.clone(authData.getMac().getOctets());
         this.unauthAttrs = authData.getUnauthAttrs();
 
         //
@@ -101,7 +101,7 @@ public class CMSAuthenticatedData
         //
         ContentInfo encInfo = authData.getEncapsulatedContentInfo();
         CMSReadable readable = new CMSProcessableByteArray(
-            ASN1OctetString.getInstance(encInfo.getContent()).getOctets());
+            Arrays.clone(ASN1OctetString.getInstance(encInfo.getContent()).getOctets()));
 
         //
         // build the RecipientInformationStore
@@ -298,7 +298,7 @@ public class CMSAuthenticatedData
     {
         if (authAttrs != null)
         {
-            return ASN1OctetString.getInstance(getAuthAttrs().get(CMSAttributes.messageDigest).getAttrValues().getObjectAt(0)).getOctets();
+            return Arrays.clone(ASN1OctetString.getInstance(getAuthAttrs().get(CMSAttributes.messageDigest).getAttrValues().getObjectAt(0)).getOctets());
         }
 
         return null;

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSAuthenticatedDataParser.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSAuthenticatedDataParser.java
@@ -247,7 +247,7 @@ public class CMSAuthenticatedDataParser
         if (mac == null)
         {
             getAuthAttrs();
-            mac = authData.getMac().getOctets();
+            mac = Arrays.clone(authData.getMac().getOctets());
         }
         return Arrays.clone(mac);
     }
@@ -345,7 +345,7 @@ public class CMSAuthenticatedDataParser
     {
         if (authAttrs != null)
         {
-            return ASN1OctetString.getInstance(authAttrs.get(CMSAttributes.messageDigest).getAttrValues().getObjectAt(0)).getOctets();
+            return Arrays.clone(ASN1OctetString.getInstance(authAttrs.get(CMSAttributes.messageDigest).getAttrValues().getObjectAt(0)).getOctets());
         }
 
         return null;

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSDigestedData.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSDigestedData.java
@@ -87,7 +87,7 @@ public class CMSDigestedData
 
         try
         {
-            return new CMSProcessableByteArray(content.getContentType(), ((ASN1OctetString)content.getContent()).getOctets());
+            return new CMSProcessableByteArray(content.getContentType(), Arrays.clone(((ASN1OctetString)content.getContent()).getOctets()));
         }
         catch (Exception e)
         {

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSEnvelopedData.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSEnvelopedData.java
@@ -10,6 +10,7 @@ import org.bouncycastle.asn1.cms.ContentInfo;
 import org.bouncycastle.asn1.cms.EncryptedContentInfo;
 import org.bouncycastle.asn1.cms.EnvelopedData;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.Encodable;
 
 /**
@@ -89,7 +90,7 @@ public class CMSEnvelopedData
             //
             EncryptedContentInfo encInfo = envData.getEncryptedContentInfo();
             this.encAlg = encInfo.getContentEncryptionAlgorithm();
-            CMSReadable readable = new CMSProcessableByteArray(encInfo.getEncryptedContent().getOctets());
+            CMSReadable readable = new CMSProcessableByteArray(Arrays.clone(encInfo.getEncryptedContent().getOctets()));
             CMSSecureReadable secureReadable = new CMSEnvelopedHelper.CMSEnvelopedSecureReadable(
                 this.encAlg, readable);
 

--- a/pkix/src/main/java/org/bouncycastle/cms/CMSSignedData.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/CMSSignedData.java
@@ -30,6 +30,7 @@ import org.bouncycastle.cert.X509AttributeCertificateHolder;
 import org.bouncycastle.cert.X509CRLHolder;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.Encodable;
 import org.bouncycastle.util.Store;
 
@@ -197,7 +198,7 @@ public class CMSSignedData
             if (content instanceof ASN1OctetString)
             {
                 this.signedContent = new CMSProcessableByteArray(signedData.getEncapContentInfo().getContentType(),
-                    ((ASN1OctetString)content).getOctets());
+                    Arrays.clone(((ASN1OctetString)content).getOctets()));
             }
             else
             {

--- a/pkix/src/main/java/org/bouncycastle/cms/KeyTransRecipientInformation.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/KeyTransRecipientInformation.java
@@ -5,6 +5,7 @@ import org.bouncycastle.asn1.cms.IssuerAndSerialNumber;
 import org.bouncycastle.asn1.cms.KeyTransRecipientInfo;
 import org.bouncycastle.asn1.cms.RecipientIdentifier;
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
+import org.bouncycastle.util.Arrays;
 
 /**
  * the KeyTransRecipientInformation class for a recipient who has been sent a secret
@@ -45,6 +46,6 @@ public class KeyTransRecipientInformation
     protected RecipientOperator getRecipientOperator(Recipient recipient)
         throws CMSException
     {
-        return ((KeyTransRecipient)recipient).getRecipientOperator(keyEncAlg, messageAlgorithm, info.getEncryptedKey().getOctets());
+        return ((KeyTransRecipient)recipient).getRecipientOperator(keyEncAlg, messageAlgorithm, Arrays.clone(info.getEncryptedKey().getOctets()));
     }
 }

--- a/pkix/src/main/java/org/bouncycastle/cms/SignerInformation.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/SignerInformation.java
@@ -72,7 +72,7 @@ public class SignerInformation
         {
             ASN1OctetString octs = ASN1OctetString.getInstance(s.getId());
 
-            sid = new SignerId(octs.getOctets());
+            sid = new SignerId(Arrays.clone(octs.getOctets()));
         }
         else
         {
@@ -85,7 +85,7 @@ public class SignerInformation
         this.signedAttributeSet = info.getAuthenticatedAttributes();
         this.unsignedAttributeSet = info.getUnauthenticatedAttributes();
         this.encryptionAlgorithm = info.getDigestEncryptionAlgorithm();
-        this.signature = info.getEncryptedDigest().getOctets();
+        this.signature = Arrays.clone(info.getEncryptedDigest().getOctets());
 
         this.content = content;
         this.resultDigest = resultDigest;
@@ -108,7 +108,7 @@ public class SignerInformation
         this.signedAttributeSet = info.getAuthenticatedAttributes();
         this.unsignedAttributeSet = info.getUnauthenticatedAttributes();
         this.encryptionAlgorithm = info.getDigestEncryptionAlgorithm();
-        this.signature = info.getEncryptedDigest().getOctets();
+        this.signature = Arrays.clone(info.getEncryptedDigest().getOctets());
         this.content = baseInfo.content;
         this.resultDigest = baseInfo.resultDigest;
         this.signedAttributeValues = baseInfo.signedAttributeValues;

--- a/pkix/src/main/java/org/bouncycastle/cms/jcajce/CMSUtils.java
+++ b/pkix/src/main/java/org/bouncycastle/cms/jcajce/CMSUtils.java
@@ -23,6 +23,7 @@ import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
 import org.bouncycastle.cms.CMSException;
 import org.bouncycastle.jcajce.util.AlgorithmParametersUtils;
 import org.bouncycastle.jcajce.util.AnnotatedPrivateKey;
+import org.bouncycastle.util.Arrays;
 
 class CMSUtils
 {
@@ -103,7 +104,7 @@ class CMSUtils
 
         if (ext != null)
         {
-            return ASN1OctetString.getInstance(ASN1OctetString.getInstance(ext).getOctets()).getOctets();
+            return Arrays.clone(ASN1OctetString.getInstance(ASN1OctetString.getInstance(ext).getOctets()).getOctets());
         }
         else
         {

--- a/pkix/src/main/java/org/bouncycastle/dvcs/CPDRequestData.java
+++ b/pkix/src/main/java/org/bouncycastle/dvcs/CPDRequestData.java
@@ -1,6 +1,7 @@
 package org.bouncycastle.dvcs;
 
 import org.bouncycastle.asn1.dvcs.Data;
+import org.bouncycastle.util.Arrays;
 
 /**
  * Data piece of DVCRequest for CPD service (Certify Possession of Data).
@@ -36,6 +37,6 @@ public class CPDRequestData
      */
     public byte[] getMessage()
     {
-        return data.getMessage().getOctets();
+        return Arrays.clone(data.getMessage().getOctets());
     }
 }

--- a/pkix/src/main/java/org/bouncycastle/dvcs/VSDRequestData.java
+++ b/pkix/src/main/java/org/bouncycastle/dvcs/VSDRequestData.java
@@ -3,6 +3,7 @@ package org.bouncycastle.dvcs;
 import org.bouncycastle.asn1.dvcs.Data;
 import org.bouncycastle.cms.CMSException;
 import org.bouncycastle.cms.CMSSignedData;
+import org.bouncycastle.util.Arrays;
 
 /**
  * Data piece of DVCS request to VSD service (Verify Signed Document).
@@ -52,7 +53,7 @@ public class VSDRequestData
      */
     public byte[] getMessage()
     {
-        return data.getMessage().getOctets();
+        return Arrays.clone(data.getMessage().getOctets());
     }
 
     /**

--- a/pkix/src/main/java/org/bouncycastle/tsp/cms/CMSTimeStampedData.java
+++ b/pkix/src/main/java/org/bouncycastle/tsp/cms/CMSTimeStampedData.java
@@ -20,6 +20,7 @@ import org.bouncycastle.operator.DigestCalculator;
 import org.bouncycastle.operator.DigestCalculatorProvider;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.bouncycastle.tsp.TimeStampToken;
+import org.bouncycastle.util.Arrays;
 
 public class CMSTimeStampedData
 {
@@ -99,7 +100,7 @@ public class CMSTimeStampedData
     {
         if (timeStampedData.getContent() != null)
         {
-            return timeStampedData.getContent().getOctets();
+            return Arrays.clone(timeStampedData.getContent().getOctets());
         }
 
         return null;

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/dstu/SignatureSpiLe.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/dstu/SignatureSpiLe.java
@@ -5,6 +5,7 @@ import java.security.SignatureException;
 
 import org.bouncycastle.asn1.ASN1OctetString;
 import org.bouncycastle.asn1.DEROctetString;
+import org.bouncycastle.util.Arrays;
 
 public class SignatureSpiLe
     extends SignatureSpi
@@ -24,7 +25,7 @@ public class SignatureSpiLe
     protected byte[] engineSign()
         throws SignatureException
     {
-        byte[] signature = ASN1OctetString.getInstance(super.engineSign()).getOctets();
+        byte[] signature = Arrays.clone(ASN1OctetString.getInstance(super.engineSign()).getOctets());
         reverseBytes(signature);
         try
         {
@@ -44,7 +45,7 @@ public class SignatureSpiLe
 
         try
         {
-            bytes = ((ASN1OctetString)ASN1OctetString.fromByteArray(sigBytes)).getOctets();
+            bytes = Arrays.clone(((ASN1OctetString)ASN1OctetString.fromByteArray(sigBytes)).getOctets());
         }
         catch (IOException e)
         {

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/x509/X509CRLImpl.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/x509/X509CRLImpl.java
@@ -379,7 +379,7 @@ abstract class X509CRLImpl
 
     public byte[] getSignature()
     {
-        return c.getSignature().getOctets();
+        return Arrays.clone(c.getSignature().getOctets());
     }
 
     public String getSigAlgName()

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/x509/X509CertificateImpl.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/asymmetric/x509/X509CertificateImpl.java
@@ -194,7 +194,7 @@ abstract class X509CertificateImpl
 
     public byte[] getSignature()
     {
-        return c.getSignature().getOctets();
+        return Arrays.clone(c.getSignature().getOctets());
     }
 
     /**

--- a/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/GOST28147.java
+++ b/prov/src/main/java/org/bouncycastle/jcajce/provider/symmetric/GOST28147.java
@@ -36,6 +36,7 @@ import org.bouncycastle.jcajce.provider.symmetric.util.BaseMac;
 import org.bouncycastle.jcajce.provider.symmetric.util.BaseWrapCipher;
 import org.bouncycastle.jcajce.provider.util.AlgorithmProvider;
 import org.bouncycastle.jcajce.spec.GOST28147ParameterSpec;
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.Strings;
 
 public final class GOST28147
@@ -378,7 +379,7 @@ public final class GOST28147
 
             if (asn1Params instanceof ASN1OctetString)
             {
-                this.iv = ASN1OctetString.getInstance(asn1Params).getOctets();
+                this.iv = Arrays.clone(ASN1OctetString.getInstance(asn1Params).getOctets());
             }
             else if (asn1Params instanceof ASN1Sequence)
             {

--- a/prov/src/main/java/org/bouncycastle/jce/provider/X509CertificateObject.java
+++ b/prov/src/main/java/org/bouncycastle/jce/provider/X509CertificateObject.java
@@ -217,7 +217,7 @@ public class X509CertificateObject
 
     public byte[] getSignature()
     {
-        return c.getSignature().getOctets();
+        return Arrays.clone(c.getSignature().getOctets());
     }
 
     /**

--- a/prov/src/main/java/org/bouncycastle/x509/extension/X509ExtensionUtil.java
+++ b/prov/src/main/java/org/bouncycastle/x509/extension/X509ExtensionUtil.java
@@ -18,6 +18,7 @@ import org.bouncycastle.asn1.DERSequence;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.util.Arrays;
 import org.bouncycastle.util.Integers;
 
 
@@ -95,7 +96,7 @@ public class X509ExtensionUtil
                     list.add(ASN1ObjectIdentifier.getInstance(genName.getName()).getId());
                     break;
                 case GeneralName.iPAddress:
-                    list.add(DEROctetString.getInstance(genName.getName()).getOctets());
+                    list.add(Arrays.clone(DEROctetString.getInstance(genName.getName()).getOctets()));
                     break;
                 default:
                     throw new IOException("Bad tag number: " + genName.getTagNo());

--- a/tls/src/main/java/org/bouncycastle/tls/crypto/impl/jcajce/JcaTlsCertificate.java
+++ b/tls/src/main/java/org/bouncycastle/tls/crypto/impl/jcajce/JcaTlsCertificate.java
@@ -33,6 +33,7 @@ import org.bouncycastle.tls.crypto.TlsCertificate;
 import org.bouncycastle.tls.crypto.TlsCryptoException;
 import org.bouncycastle.tls.crypto.TlsVerifier;
 import org.bouncycastle.tls.crypto.impl.RSAUtil;
+import org.bouncycastle.util.Arrays;
 
 /**
  * Implementation class for a single X.509 certificate based on the JCA.
@@ -152,7 +153,7 @@ public class JcaTlsCertificate
     public byte[] getExtension(ASN1ObjectIdentifier extensionOID) throws IOException
     {
         byte[] encoding = certificate.getExtensionValue(extensionOID.getId());
-        return encoding == null ? null : ((ASN1OctetString)ASN1Primitive.fromByteArray(encoding)).getOctets();
+        return encoding == null ? null : Arrays.clone(((ASN1OctetString)ASN1Primitive.fromByteArray(encoding)).getOctets());
     }
 
     public BigInteger getSerialNumber()


### PR DESCRIPTION
ASN1OctetString löscht beim Entfernen des Objekts durch den GC den Inhalt des internen Byte-Arrays. Das interne Array wird allerdings auch nach außen gegeben. Und da nicht immer dabei eine defensive Copy erstellt wird, kann es in hohen last Situationen dazu kommen, dass es auf das eigentlich mal genutzte ASN1OctetString Objekt keine Referenz mehr gibt (gerade wenn es nur ein sehr kurzlebiges ASN1OctetString Objekt war). Dann wird durch den GC das ASN1OctetString Objekt entfernt und dabei auch das interne Array genullt wird. Wurde für dieses Array aber keine defensive Copy erstellt und wird es dann noch woanders genutzt, kommt es zu Fehlern.
Speziell wurde dies im Zusammenhang mit der Klasse org.bouncycastle.asn1.cms.GCMParameters beobachtet. Aber auch andre Stellen wo nur ein kurzlebiges ASN1OctetString Objekt verwendet werden und keine defensive Copy des Byte-Arrays erstellt wurden, wurden entsprechend angepasst und damit für den Fall der Last-Situation gesichert.